### PR TITLE
Added instructions to remove terminal history for macos/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Where the 4 arguments are:
 - account - The index of the account you are using, e.g `0`
 - address - The index of the address you are using, e.g. `0`
 
+Mac OS / Linux:
+
+- `history -c` once completed to delete terminal history
+
 Example:
 
   `npm start kusama "abandon ... about" 0 0`


### PR DESCRIPTION
The mnemonic seed phrase will always be in the terminal history for macos/linux which isn't safe. I added instructions to remove it in the readme. 